### PR TITLE
Ics 3.0 sod fix

### DIFF
--- a/arch/arm/mach-msm/devices-msm7x30.c
+++ b/arch/arm/mach-msm/devices-msm7x30.c
@@ -1229,7 +1229,7 @@ static struct resource kgsl_2d0_resources[] = {
 static struct kgsl_device_platform_data kgsl_2d0_pdata = {
 	.pwrlevel = {
 		{
-			.gpu_freq = 192000000,
+			.gpu_freq = 0,
 			.bus_freq = 192000000,
 		},
 	},

--- a/drivers/gpu/msm/kgsl_pwrctrl.c
+++ b/drivers/gpu/msm/kgsl_pwrctrl.c
@@ -373,16 +373,17 @@ void kgsl_pwrctrl_clk(struct kgsl_device *device, int state,
 			&pwr->power_flags)) {
 			trace_kgsl_clk(device, state);
 			/* High latency clock maintenance. */
-			if ((pwr->pwrlevels[0].gpu_freq > 0) &&
-				(device->state != KGSL_STATE_NAP)) {
+			if (device->state != KGSL_STATE_NAP) {
 				for (i = KGSL_MAX_CLKS - 1; i > 0; i--)
 					if (pwr->grp_clks[i])
 						clk_prepare(pwr->grp_clks[i]);
-				clk_set_rate(pwr->grp_clks[0],
-					pwr->pwrlevels[pwr->active_pwrlevel].
+
+				if (pwr->pwrlevels[0].gpu_freq > 0)
+					clk_set_rate(pwr->grp_clks[0],
+						pwr->pwrlevels
+						[pwr->active_pwrlevel].
 						gpu_freq);
 			}
-
 			/* as last step, enable grp_clk
 			   this is to let GPU interrupt to come */
 			for (i = KGSL_MAX_CLKS - 1; i > 0; i--)


### PR DESCRIPTION
Hi Arne,
these 3 commits, in particular the last one, solved the SOD problems that we had on our I9001 using CM9 RC4/5/6.
I made several attempts to circumscribe more precisely the point that caused the SOD and in the end I found that the real cause was the suspending procedure of Adreno 2D device driver (z180_platform_driver).
In some cases, being a synchronization issue, setting the clock of the gpu (kgsl_pwrctrl_pwrlevel_change) during the suspension, causing the hang.

I made a first attempt setting the gpu clock to 0 in the 2D gpu driver configuration (arch/arm/mach-msm/devices-msm7x30.c), as already adopted on the branch jb-3.0 and cm-10.1:
 static struct kgsl_device_platform_data kgsl_2d0_pdata = {
   .pwrlevel = {
     {
       .gpu_freq = 0,
       .bus_freq = 192000000,
     },
   },

After some time, seeing that already the SOD didn't happen anymore, I tried to understand where that change came from by looking on jb-3.0 branch.
At the end I found the patch (applied by you and CAF team on jb-3.0 branch) which included that change and the complete fix of the noticed bug, I finally applied it on ics-3.0 too with two other patches, surely very useful in ensuring the stability of the power management of that driver.
I hope that the damn sod won't happen anymore...

Thank you very much for your awesome work!
